### PR TITLE
Fix alt li

### DIFF
--- a/style.css
+++ b/style.css
@@ -54,6 +54,14 @@ li:before {
     width: 1.5em;
 }
 
+li.alt {
+    margin-left: 1.5em;
+}
+
+li.alt:before {
+   content: "\2053";
+}
+
 img {
     display: block;
     margin-left: auto;


### PR DESCRIPTION
@Hardmath123 Please review :)

With the original CSS, `~~` was not displayed differently than regular `~`; this PR addresses this discrepancy. 
